### PR TITLE
App name is now Lavadito Solves #32

### DIFF
--- a/Lavadito/Lavadito.Android/Properties/AndroidManifest.xml
+++ b/Lavadito/Lavadito.Android/Properties/AndroidManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.lavadito" android:installLocation="preferExternal">
 	<uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-	<application android:label="in" android:icon="@mipmap/ic_launcher_new"></application>
+	<application android:label="Lavadito" android:icon="@mipmap/ic_launcher_new"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
App Name in Android-Properties was unintencionally changed to "in". This commit changes that name back to Lavadito.